### PR TITLE
Arrumado o __pycache__ aparecendo no GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,12 +14,12 @@ reasoning
 ignore_list
 pyenv
 cid
-__pycache__
+__pycache__/
 __venv__
 .idea
 __pycache__
 teste
-__venv__
+__venv__/
 venv
 .gemini
 .pyen


### PR DESCRIPTION
Arrumei o `.gitignore` para ignorar esta pasta.

## Summary by Sourcery

Chores:
- Add `__pycache__` to `.gitignore`